### PR TITLE
Fixed requirements.txt for python versions >3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ asyncpraw==7.5.0
 asyncprawcore==2.3.0
 attrs==21.4.0
 Babel==2.10.3
-backports.zoneinfo==0.2.1
+backports.zoneinfo==0.2.1;python_version<"3.9"
 beautifulsoup4==4.10.0
 bs4==0.0.1
 cchardet==2.1.7


### PR DESCRIPTION
This commit fixes build issues for dependency "backports.zoneinfo" on python versions greater than 3.9.

It avoids installation of "backports.zoneinfo" on python versions greater than 3.9 since it is a builtin library.